### PR TITLE
Bump aws-cdk to 1.26.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apk -U --no-cache add \
     nodejs \
     npm \
     perl=5.28.2-r1 &&\
-    npm i -g aws-cdk@v1.16.2 &&\
+    npm i -g aws-cdk@v1.26.0 &&\
     pip3 install -r cdk-packages.txt &&\
     pip3 install awscli &&\
     rm -rf /var/cache/apk/*


### PR DESCRIPTION
Bumping to `aws-cdk@1.26.0` from `1.16.2`.

There are a number of changes, including breaking changes detailed here:
https://github.com/aws/aws-cdk/releases

These important changes include the following modules:
* route53
* cloudfront
* autoscaling
* rds
* glue
* eks
* core (`Arn.parseArn`)
* ec2-assets
* appsync
* apigateway
* lambda-nodejs